### PR TITLE
Removed the optional package import of javax.inject from MANIFEST.MF and...

### DIFF
--- a/bundles/org.jupnp/META-INF/MANIFEST.MF
+++ b/bundles/org.jupnp/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*
-Import-Package: javax.inject;resolution:=optional,
- javax.servlet,
+Import-Package: javax.servlet,
  javax.servlet.http,
  org.apache.http,
  org.apache.http.client,

--- a/bundles/org.jupnp/build.properties
+++ b/bundles/org.jupnp/build.properties
@@ -3,3 +3,4 @@ bin.includes = META-INF/,\
                .,\
                OSGI-INF/
 source.. = src/main/java/
+jars.extra.classpath = platform:/plugin/javax.inject


### PR DESCRIPTION
... added it to build.properties jars.extra.classpath as it is only needed compile time.

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>