### PR TITLE
Fixed an issue where multicastResponsePort configuration property is …

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
@@ -143,7 +143,7 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
     }
 
     public int getMulticastResponsePort() {
-        return DEFAULT_MULTICAST_RESPONSE_LISTEN_PORT;
+        return multicastResponsePort > 0 ? multicastResponsePort : DEFAULT_MULTICAST_RESPONSE_LISTEN_PORT;
     }
 
     public int getStreamListenPort() {


### PR DESCRIPTION
…not taken into account and instead an ephemeral port is always used.

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>